### PR TITLE
008 search tasks

### DIFF
--- a/src/controllers/tasks.controller.ts
+++ b/src/controllers/tasks.controller.ts
@@ -130,8 +130,7 @@ export const searchTask = async (title: string): Promise<void> => {
   try {
     const tasks = await readJsonFile();
     const regex = new RegExp(title, 'i'); // 'i' flag for case-insensitive search
-    const searchResult = tasks.filter((task) => regex.test(task.name));
-    console.log(searchResult);
+    displayTasks(tasks.filter((task) => regex.test(task.name)));
   } catch (error) {
     console.error(error);
   }

--- a/src/controllers/tasks.controller.ts
+++ b/src/controllers/tasks.controller.ts
@@ -129,8 +129,13 @@ export const modifyTask = async (id: string, options: { status: string; archive:
 export const searchTask = async (title: string): Promise<void> => {
   try {
     const tasks = await readJsonFile();
-    const regex = new RegExp(title, 'i'); // 'i' flag for case-insensitive search
-    displayTasks(tasks.filter((task) => regex.test(task.name)));
+    // replace multiple spaces with one space and trim leading and trailing space
+    const sanitizedSearchTitle = title.replace(/\s+/g, ' ').trim().toLowerCase();
+    const searchTitleWords = sanitizedSearchTitle.split(' ');
+    const filteredTasks = tasks.filter((task) => {
+      return searchTitleWords.every((word) => task.name.toLowerCase().includes(word));
+    });
+    displayTasks(filteredTasks);
   } catch (error) {
     console.error(error);
   }

--- a/src/controllers/tasks.controller.ts
+++ b/src/controllers/tasks.controller.ts
@@ -125,3 +125,14 @@ export const modifyTask = async (id: string, options: { status: string; archive:
     console.error(error);
   }
 };
+
+export const searchTask = async (title: string): Promise<void> => {
+  try {
+    const tasks = await readJsonFile();
+    const regex = new RegExp(title, 'i'); // 'i' flag for case-insensitive search
+    const searchResult = tasks.filter((task) => regex.test(task.name));
+    console.log(searchResult);
+  } catch (error) {
+    console.error(error);
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Command, Option } from 'commander';
-import { createTask, viewTasks, deleteTask, modifyTask } from '@src/controllers/tasks.controller';
+import { createTask, viewTasks, deleteTask, modifyTask, searchTask } from '@src/controllers/tasks.controller';
 import { handleStorageExist } from '@src/utils/checkFile';
 import path from 'path';
 
@@ -61,6 +61,8 @@ const run = async (): Promise<void> => {
     .option('-ar, --archive', 'Toggle the archive status of a task')
     .action(modifyTask)
     .showHelpAfterError();
+
+  program.command('search <title>').description('Search the tasks by title').action(searchTask).showHelpAfterError();
 
   program.parse(process.argv);
 };


### PR DESCRIPTION
I have added the feature for searching the task by their name. Here is the overview of this feature:
- [x] Search the tasks in the list by their name.  (run ```npm run dev -- search <task_name>```)

The following are the file changes:
- In index.ts, I have added extra command: search that takes an argument task title in string format. For CLI convention, we have to pass task title in double or single quote if the search title has more than one word.
- In tasks.controller.ts, I have created a new method searchTask that accepts title as argument which is the actual search query for the task.